### PR TITLE
Added my own extention for VScode

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,3 +7,4 @@ vscode:
     - ms-python.python@2019.8.30787:TnGEOx35GXMhyKLjDGz9Aw==
     - formulahendry.auto-close-tag@0.5.6:oZ/8R2VhZEhkHsoeO57hSw==
     - mkaufman.HTMLHint@0.6.0:TdNYbCmjW8N3yiaPW4/adg==
+    - eventyret.bootstrap-4-cdn-snippet@1.2.3:7CBqCsMp6UjSKmG+LTaUGw==


### PR DESCRIPTION
Added my own vscode plugin to help students with a quicker start [Marketplace Link](https://marketplace.visualstudio.com/items?itemName=eventyret.bootstrap-4-cdn-snippet)

Students can now use `!bcdn` to create a full template with bootstrap etc.
Any questions about it let me know.