### PR TITLE
Added python and pip aliases to init_tasks.sh

### DIFF
--- a/init_tasks.sh
+++ b/init_tasks.sh
@@ -16,6 +16,8 @@ echo ".headers on" > ~/.sqliterc
 echo ".mode column" >> ~/.sqliterc
 echo "Adding run aliases"
 echo 'alias run="python3 $GITPOD_REPO_ROOT/manage.py runserver 0.0.0.0:8000"' >> ~/.bashrc
+echo 'alias python=python3' >> ~/.bashrc
+echo 'alias pip=pip3' >> ~/.bashrc
 echo "Checking for pip upgrade"
 pip3 install --upgrade pip
 echo "Done"


### PR DESCRIPTION
Just adding a couple aliases to bashrc. This will allow students to default to python3 and pip3 even if they mistakenly type only `python` or `pip` ... to use python/pip v2 they will need to explicitly specify `python2` or `pip2`