### PR TITLE
feat: Add 'Beautify' / Remove 'Prettier' on .gitpod.yml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,5 +8,5 @@ vscode:
     - formulahendry.auto-close-tag@0.5.6:oZ/8R2VhZEhkHsoeO57hSw==
     - mkaufman.HTMLHint@0.6.0:TdNYbCmjW8N3yiaPW4/adg==
     - eventyret.bootstrap-4-cdn-snippet@1.6.0:AtNd6GnbCYVpmUkOaFXs3A==
-    - esbenp.prettier-vscode@4.3.0:jkl8NYpF/GzsahVpjggK0Q==
+    - HookyQR.beautify@1.5.0:mXo/OcopUVNHHxCPZWwlxQ==
     - kevinglasson.cornflakes-linter@0.4.0:Sgfmpf9YWoF5/BDJu2xn0w==

--- a/.theia/keymaps.json
+++ b/.theia/keymaps.json
@@ -1,0 +1,12 @@
+[
+    {
+        "command": "HookyQR.beautifyFile",
+        "keybinding": "ctrl+shift+b",
+        "when": "editorFocus"
+    },
+    {
+        "command": "HookyQR.beautify",
+        "keybinding": "ctrl+alt+b",
+        "when": "editorFocus"
+    }
+]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ In Gitpod you have superuser security privileges by default. Therefore you do no
 
 We continually tweak and adjust this template to help give you the best experience. Here are the updates since the original video was made:
 
+**June 2020:** Added the _Beautify_ code beautifier extension in lieu of the _Prettier_ extension. Use `Ctrl+Shift+B` to format entire file, or `Ctrl+Alt+B` to format a selection.
+
 **April 16 2020:** The template now automatically installs MySQL instead of relying on the Gitpod MySQL image. The message about a Python linter not being installed has been dealt with, and the set-up files are now hidden in the Gitpod file explorer.
 
 **April 13 2020:** Added the _Prettier_ code beautifier extension instead of the code formatter built-in to Gitpod.


### PR DESCRIPTION
Requesting to change formatting extension from [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) to [Beautify](https://marketplace.visualstudio.com/items?itemName=HookyQR.beautify).

Gitpod doesn't recognize `Ctrl+Shift+P` for **Prettier**, and the built-in formatter for Gitpod breaks elements poorly.
**Beautify** format is `Ctrl+Shift+B` for entire document, or `Ctrl+Alt+B` for selected area only.