### PR TITLE
feat: additional .gitignore files added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 core.Microsoft*
+core.mongo*
+core.python*
 env.py
 __pycache__/
 *.py[cod]

--- a/.theia/settings.json
+++ b/.theia/settings.json
@@ -16,6 +16,8 @@
       "**/.DS_Store": true,
       "**/.theia": true,
       "**/core.Microsoft*": true,
+      "**/core.mongo*": true,
+      "**/core.python*": true,
    },
    "emmet.extensionsPath": ".theia"
 }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ In Gitpod you have superuser security privileges by default. Therefore you do no
 
 We continually tweak and adjust this template to help give you the best experience. Here are the updates since the original video was made:
 
-**September 22 2020:** Gitpod occasionally creates large `core.Microsoft` files. These are now hidden in the Explorer. A `.gitignore` file has been created to make sure these files will not be committed along with other common files.
+**October 08 2020:** Additional large Gitpod files (`core.mongo*` and `core.python*`) are now hidden in the Explorer, and have been added to the `.gitignore` by default.
+
+**September 22 2020:** Gitpod occasionally creates large `core.Microsoft` files. These are now hidden in the Explorer. A `.gitignore` file has been created to make sure these files will not be committed, along with other common files.
 
 **April 16 2020:** The template now automatically installs MySQL instead of relying on the Gitpod MySQL image. The message about a Python linter not being installed has been dealt with, and the set-up files are now hidden in the Gitpod file explorer.
 


### PR DESCRIPTION
ISSUE:
- Gitpod has started adding new **`core.foo`** files, causing a mess when students commit their work. The files are too massive, and create a mess on their workspace.

FIX:
- Added **`core.mongo*`** and **`core.python*`** to the **`.gitignore`** file, and **`.theia/settings.json`** file to hide in the Explorer.