### PR TITLE
Fix: update README image to Markdown format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://codeinstitute.s3.amazonaws.com/fullstack/ci_logo_small.png" style="margin: 0;">
+![CI logo](https://codeinstitute.s3.amazonaws.com/fullstack/ci_logo_small.png)
 
 Welcome USER_NAME,
 


### PR DESCRIPTION
Issue:
- README uses Markup for logo `<img>`.

Fix:
- Corrected to Markdown format using `![alt](path)` instead of `<img>`.

Several students see HTML Markup on the template README and assume that the README file should use this standard when applying images, instead of Markdown formatting on the .md file. This should hopefully decrease the amount of projects seen using HTML Markup by the time their projects go for assessments.