### PR TITLE
Remove formatOnSave true from settings.json.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,19 +8,17 @@
    "python.linting.flake8Path": "/home/gitpod/.pyenv/shims/flake8",
    "cornflakes.linter.executablePath": "/home/gitpod/.pyenv/shims/flake8",
    "files.exclude": {
+      "**/.DS_Store": true,
       "**/.git": true,
       "**/.gitp*": true,
-      "**/.svn": true,
       "**/.hg": true,
-      "**/CVS": true,
-      "**/.DS_Store": true,
-      "**/.vscode": true,
+      "**/.svn": true,
       "**/core.Microsoft*": true,
       "**/core.mongo*": true,
-      "**/core.python*": true
+      "**/core.python*": true,
+      "**/CVS": true
    },
    "files.autoSave": "off",
    "workbench.colorTheme": "Visual Studio Dark",
    "editor.defaultFormatter": "HookyQR.beautify",
-   "editor.formatOnSave": true
 }


### PR DESCRIPTION
As per Tims [request in Slack](https://code-institute-room.slack.com/archives/G6MPTJJ5C/p1618418096014100?thread_ts=1617792956.011200&cid=G6MPTJJ5C)
Removed **"editor.formatOnSave": true** from settings.json because it was causing random errors with formatting, like env.py files being formatted and breaking MONGO_URI strings.