### PR TITLE
feat: Add reset process note for API key

### DIFF
--- a/.vscode/heroku_config.sh
+++ b/.vscode/heroku_config.sh
@@ -22,5 +22,12 @@ if [[ -z "${HEROKU_API_KEY}" ]]; then
    . ~/.bashrc > /dev/null
    echo Done!
 else
-   echo API key is already set. Exiting
+   echo API key is already set.
+   echo
+   echo In the event of an error with the API key, use the following command:
+   echo
+   echo unset HEROKU_API_KEY
+   echo
+   echo This will clear the API key and allow you to run heroku_config again.
+   echo Exiting with existing API key set.
 fi


### PR DESCRIPTION
With 2FA/MFA being more prominent with Heroku and the recent change to disable
automatic deployment, I suggest adding a note regarding the process to clear any 
erroneous API keys - I have helped students with this 3 times in 24 hours so just
trying to save Tutor Support time going forward.