### PR TITLE
feat: Add ability to type `reset` to reset API key

### DIFF
--- a/.vscode/heroku_config.sh
+++ b/.vscode/heroku_config.sh
@@ -24,13 +24,15 @@ if [[ -z "${HEROKU_API_KEY}" ]]; then
 else
    echo API key is already set.
    echo
-   echo To reset the API key please input `reset`:
+   echo To reset the API key please input "'reset'":
    read reset_trigger
    if [[ ${reset_trigger} == reset ]]; then
       unset HEROKU_API_KEY
+      echo
       echo API key removed!
    else
       echo API key unchanged.
    fi
+   echo
    echo Exiting
 fi

--- a/.vscode/heroku_config.sh
+++ b/.vscode/heroku_config.sh
@@ -22,5 +22,15 @@ if [[ -z "${HEROKU_API_KEY}" ]]; then
    . ~/.bashrc > /dev/null
    echo Done!
 else
-   echo API key is already set. Exiting
+   echo API key is already set.
+   echo
+   echo To reset the API key please input `reset`:
+   read reset_trigger
+   if [[ ${reset_trigger} == reset ]]; then
+      unset HEROKU_API_KEY
+      echo API key removed!
+   else
+      echo API key unchanged.
+   fi
+   echo Exiting
 fi

--- a/.vscode/heroku_config.sh
+++ b/.vscode/heroku_config.sh
@@ -28,9 +28,11 @@ else
    read reset_trigger
    if [[ ${reset_trigger} == reset ]]; then
       unset HEROKU_API_KEY
+      unset reset_trigger
       echo
       echo API key removed!
    else
+      unset reset_trigger
       echo API key unchanged.
    fi
    echo


### PR DESCRIPTION
As an alternative to providing the reset command and having users
enter it themselves (#22), added input of `reset` to trigger API key
removal when `heroku_config` is run with API key set.

Feel free to squash these commits into one, no need for such a
verbose history for a small modification IMHO.