### PR TITLE
Update Python/PEP8 linters

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,8 @@
 {
-   "python.linting.pylintEnabled": true,
+   "python.linting.pylintEnabled": false,
    "python.linting.enabled": true,
-   "python.linting.pep8Enabled": false,
-   "python.linting.flake8Enabled": true,
+   "python.linting.pycodestyleEnabled": true,
+   "python.linting.flake8Enabled": false,
    "python.terminal.activateEnvironment": false,
    "python.formatting.autopep8Path": "/home/gitpod/.pyenv/shims/autopep8",
    "python.linting.flake8Path": "/home/gitpod/.pyenv/shims/flake8",


### PR DESCRIPTION
This has been a known bug since at least February 2022, and I've been helping my students change this on every workspace so the `flake8` and `pylint` warnings (unnecessary squiggly blue/yellow lines all over the code). Enabling `pycodestyle` aligns 100% compliant with pep8online.com.

Otherwise, this is the screenshot I'd have to send out regularly.

![image](https://user-images.githubusercontent.com/41592028/180397507-5d98e788-6352-4d28-ba2b-d3adb681e5ab.png)
