### PR TITLE
build: Update python verison to 3.9.17 in dockerfile

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -17,6 +17,7 @@ ENV PATH=$PATH:/home/gitpod/.nvm/versions/node/v${NODE_VERSION}/bin
 ### Python ###
 USER gitpod
 RUN sudo install-packages python3-pip
+ENV PYTHON_VERSION 3.9.17
 
 ENV PATH=$HOME/.pyenv/bin:$HOME/.pyenv/shims:$PATH
 RUN curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
@@ -24,8 +25,8 @@ RUN curl -fsSL https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-ins
         echo 'eval "$(pyenv init -)"'; \
         echo 'eval "$(pyenv virtualenv-init -)"'; } >> /home/gitpod/.bashrc.d/60-python \
     && pyenv update \
-    && pyenv install 3.8.11 \
-    && pyenv global 3.8.11 \
+    && pyenv install $PYTHON_VERSION \
+    && pyenv global $PYTHON_VERSION \
     && python3 -m pip install --no-cache-dir --upgrade pip \
     && python3 -m pip install --no-cache-dir --upgrade \
         setuptools wheel virtualenv pipenv pylint rope flake8 \

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ You can now use the `heroku` CLI program - try running `heroku apps` to confirm 
 
 We continually tweak and adjust this template to help give you the best experience. Here is the version history:
 
+**September 20 2023:** Update Python version to 3.9.17.
+
 **September 1 2021:** Remove `PGHOSTADDR` environment variable.
 
 **July 19 2021:** Remove `font_fix` script now that the terminal font issue is fixed.


### PR DESCRIPTION
Updated Python version and used an `ENV` var for the version number
to improve maintainability. This fixes `backend.zoneinfo` errors
that arise when following proposed new content.

Tested a Heroku Django deployment on a separate branch to ensure no
`backend.zoneinfo` errors were reported. Test was successful.